### PR TITLE
Enable the creation of self-contained binary files for the miner proxy, and automate them with github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,6 @@ jobs:
           build-args: RELEASE=${{ steps.get_version.outputs.VERSION-NO-V }}
           platforms: linux/amd64
           tags: |
-            docker.io/capito27/mining-proxy:${{ steps.get_version.outputs.VERSION }}
-            docker.io/capito27/mining-proxy:latest
+            docker.io/alephium/mining-proxy:${{ steps.get_version.outputs.VERSION }}
+            docker.io/alephium/mining-proxy:latest
           push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,12 +151,12 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-linux
-            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-linux.checksum
-            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-macos
-            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-macos.checksum
-            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-windows.exe
-            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-windows.exe.checksum
+            alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-linux
+            alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-linux.checksum
+            alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-macos
+            alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-macos.checksum
+            alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-windows.exe
+            alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-windows.exe.checksum
 
   buildx_and_push_to_registry:
     name: Push Docker image to Docker Hub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,198 @@
+name: build artifacts
+on: [ push ]
+
+jobs:
+  build-linux-artifact:
+    name: build-linux-artifact
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Cache Dependencies
+        uses: actions/cache@v2
+        id: cache-deps
+        with:
+          path: .\node_modules
+          key: ${{ runner.os }}-${{ hashFiles('package-lock.json', 'package.json') }}
+
+      - name: Install build dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm install
+
+      - name: Build mining proxy
+        run: npm run build -- --targets node16-linux-x64
+
+      - name: Rename mining proxy
+        run: mv bin/alephium-mining-proxy bin/alephium-mining-proxy-linux_$(git rev-parse --short "$GITHUB_SHA")
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: linux-binary
+          path: bin/alephium-mining-proxy-linux_*
+
+  build-macos-artifact:
+    name: build-macos-artifact
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Cache Dependencies
+        uses: actions/cache@v2
+        id: cache-deps
+        with:
+          path: .\node_modules
+          key: ${{ runner.os }}-${{ hashFiles('package-lock.json', 'package.json') }}
+
+      - name: Install build dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm install
+
+      - name: Build mining proxy
+        run: npm run build -- --targets node16-macos-x64
+
+      - name: Rename mining proxy
+        run: mv bin/alephium-mining-proxy bin/alephium-mining-proxy-macos_$(git rev-parse --short "$GITHUB_SHA")
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: macos-binary
+          path: bin/alephium-mining-proxy-macos_*
+
+  build-windows-artifact:
+    name: build-windows-artifact
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+
+      - name: Cache Dependencies
+        uses: actions/cache@v2
+        id: cache-deps
+        with:
+          path: |
+            .\node_modules
+            "C:\OpenSSL-Win64\lib\"
+            "C:\Program Files\OpenSSL-Win64"
+          key: ${{ runner.os }}-${{ hashFiles('package-lock.json', 'package.json') }}
+
+      - name: Install build dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          choco install openssl --no-progress
+          New-Item C:\OpenSSL-Win64\lib -ItemType Directory
+          New-Item -ItemType SymbolicLink -Path "C:\OpenSSL-Win64\lib\libeay32.lib" -Target "C:\Program Files\OpenSSL-Win64\lib\libcrypto.lib"
+          npm install
+
+      - name: Build mining proxy
+        run: npm run build -- --targets node16-windows-x64
+
+      - name: Rename mining proxy
+        run: mv bin/alephium-mining-proxy.exe bin/alephium-mining-proxy-windows_$(git rev-parse --short "$GITHUB_SHA").exe
+        shell: bash
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows-binary
+          path: bin/alephium-mining-proxy-windows_*
+
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    needs: [build-linux-artifact, build-macos-artifact, build-windows-artifact]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get linux artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-binary
+
+      - name: Get macos artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: macos-binary
+
+      - name: Get Windows artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: windows-binary
+
+      - name: Get the version (Release prep)
+        id: get_version
+        run: |
+          version=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
+          echo ::set-output name=VERSION::$version
+        shell: bash
+
+      - name: Generate miner proxies checksums (Release prep)
+        run: |
+          filename=$(git rev-parse --short HEAD)
+          mv "alephium-mining-proxy-linux_$filename" "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-linux"
+          mv "alephium-mining-proxy-macos_$filename" "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-macos"
+          mv "alephium-mining-proxy-windows_$filename.exe" "alephium-mining-proxy-windows-${{ steps.get_version.outputs.VERSION }}.exe"
+          sha256sum "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-linux" > "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-linux.checksum"
+          sha256sum "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-macos" > "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-macos.checksum"
+          sha256sum "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-windows.exe" > "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-windows.exe.checksum"
+          ls -la
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-linux
+            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-linux.checksum
+            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-macos
+            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-macos.checksum
+            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-windows.exe
+            alephium-${{ steps.get_version.outputs.VERSION }}-mining-proxy-windows.exe.checksum
+
+  buildx_and_push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+
+      - name: Get the version
+        id: get_version
+        run: |
+          version=$(git describe --tags --abbrev=0)
+          echo $version
+          echo ${version:1}
+          echo ::set-output name=VERSION::$version
+          echo ::set-output name=VERSION-NO-V::${version:1}
+        shell: bash
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and publish docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: RELEASE=${{ steps.get_version.outputs.VERSION-NO-V }}
+          platforms: linux/amd64
+          tags: |
+            docker.io/capito27/mining-proxy:${{ steps.get_version.outputs.VERSION }}
+            docker.io/capito27/mining-proxy:latest
+          push: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           filename=$(git rev-parse --short HEAD)
           mv "alephium-mining-proxy-linux_$filename" "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-linux"
           mv "alephium-mining-proxy-macos_$filename" "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-macos"
-          mv "alephium-mining-proxy-windows_$filename.exe" "alephium-mining-proxy-windows-${{ steps.get_version.outputs.VERSION }}.exe"
+          mv "alephium-mining-proxy-windows_$filename.exe" "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-windows.exe"
           sha256sum "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-linux" > "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-linux.checksum"
           sha256sum "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-macos" > "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-macos.checksum"
           sha256sum "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-windows.exe" > "alephium-mining-proxy-${{ steps.get_version.outputs.VERSION }}-windows.exe.checksum"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+bin/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,28 @@ run miner:
 gpu-miner -p 30032
 ```
 
+# Build miner proxy
 
+N.B : At this point in time, it is only possible to build binaries for windows, linux and MacOS for the x64 architecture
+
+Dependencies :
+- install node.js(>=14), npm(>=8) and python(>=3.7)
+- Usual compilation tools (build-essentials for linux, Visual studio for windows, ...)
+- For windows : [openssl chocolatey package](https://community.chocolatey.org/packages/OpenSSL) 
+
+One can build the miner proxy into a self-contained binary file with the following, platform-specific, commands:
+```shell
+npm install
+# Build for linux
+npm run build -- --targets node16-linux-x64
+# Build for windows
+npm run build -- --targets node16-windows-x64 
+# Build for macos
+npm run build -- --targets node16-macos-x64
+```
+N.B : Cross-compiling provided broken binaries, as such, only build for the same target as the building machine
+
+The final executable can be found in the 'bin' directory.
 
 # Docker and docker-compose setup
 

--- a/block.js
+++ b/block.js
@@ -1,4 +1,4 @@
-var blake3 = require('blake3');
+const {blake3} = require("@napi-rs/blake-hash");
 
 const GroupSize = global.GroupSize = 4;
 const EncodedHeaderSize = 326;
@@ -32,7 +32,7 @@ var Block = module.exports = function(buffer){
     this.nonce = buffer.slice(0, NonceSize)
     this.headerBlob = buffer.slice(NonceSize, EncodedHeaderSize);
     this.header = Buffer.concat([this.nonce, this.headerBlob]);
-    this.hash = blake3.hash(blake3.hash(this.header));
+    this.hash = blake3(blake3(this.header));
     this.txsBlob = buffer.slice(EncodedHeaderSize);
 
     var index = chainIndex(this.hash);

--- a/config.json.template
+++ b/config.json.template
@@ -1,5 +1,6 @@
 {
     "diff1TargetNumZero": 30,
+    "jobSize": 30,
     "serverHost": "{{.env.SERVER_HOST}}",
     "serverPort": {{.env.SERVER_PORT}},
     "proxyPort": {{.env.PROXY_PORT}},

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,222 @@
       "name": "alephium-mining-proxy",
       "version": "0.0.1",
       "dependencies": {
+        "@napi-rs/blake-hash": "1.3.0",
         "base58-native": "*",
         "bignum": "0.13.1",
-        "binary-parser": "2.0.2",
-        "blake3": "2.1.7"
+        "binary-parser": "2.0.2"
+      },
+      "bin": {
+        "proxy": "init.js"
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash/-/blake-hash-1.3.0.tgz",
+      "integrity": "sha512-jPeAYGhP7J0vZecIIZz2dSx7ZW4zfhwR+zKEcbdRSGSyA240H9P6wVRtw1OWzIfMhE0X7rzZcOxZvl6CKI+Efg==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/blake-hash-android-arm64": "1.3.0",
+        "@napi-rs/blake-hash-darwin-arm64": "1.3.0",
+        "@napi-rs/blake-hash-darwin-x64": "1.3.0",
+        "@napi-rs/blake-hash-freebsd-x64": "1.3.0",
+        "@napi-rs/blake-hash-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/blake-hash-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/blake-hash-linux-arm64-musl": "1.3.0",
+        "@napi-rs/blake-hash-linux-x64-gnu": "1.3.0",
+        "@napi-rs/blake-hash-linux-x64-musl": "1.3.0",
+        "@napi-rs/blake-hash-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/blake-hash-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/blake-hash-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-android-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-android-arm64/-/blake-hash-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-ADQB/N20z6ylNxbjzbxExtphrJb5HPC85pkc81C+KHS35b2e0j9pyzAhFgK3jUVJhHfJDVv6A6bhcTM9UNuP8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-darwin-arm64/-/blake-hash-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-Sh2jgMkKfC43FnsSWb8B23CURAmlO25agk+suIUIglHwQaRe5BKVVlJ5dpM0A0Zfu3zp5HH2GveYJf4wbFP79g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-darwin-x64/-/blake-hash-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-NdMrOClD02LKRCBbFNuCzuSGiwXE7zjoiQZ3l1XyVHzVm3lI5KuoqkKBHqMuJnzUdvya3I8lT3gDrbu++Lb8nQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-freebsd-x64/-/blake-hash-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-8V7H0o317+mevBe2Rt5X98mSejHmd4pUtVLhmVcdvV3mVG/AkG7Yg6KQ5qO5krUYN3q4L5k5YkkyFkFKnQ+S5g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm-gnueabihf/-/blake-hash-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-DYLrSBop5rbPsT61Kh8NDix33+x6QaQDXFymWKZ53eUtnwbI+vufA8kGElaVv8/g9/Q4SvuHs9ddiRdRWVZu7w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm64-gnu/-/blake-hash-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-7NyNtetsGyCgUT/FWJSW/XElBujl5dGAp0sMjcXHMSEoNK98kVMmTLSzvBc3lLAU9F22WPUl0gbKlfEuzLqSXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm64-musl/-/blake-hash-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-56CP0W+2epbehbJtXTcZS7HhjszDVetSs1GucDdeY3b+oIl5afPWV4b4CtkH+atKb+0FTcc4HFZnT4/Zu46N0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-x64-gnu/-/blake-hash-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-00Idj9+JtCe4u/Cx/VvYsdUdNklP6oqKvRu0XSRuchO43LppihrN1Ew4Q/O0OjuWQQ1KyZhGmTjp63uSBP4dug==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-x64-musl/-/blake-hash-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-znEOeC5ku8OpzTDwEKdnLNErTJw1QJCgV5u9ZmxebQeHKzXKiiRDO1N4PLtQo0Y+uVV1iuYZP/ZWGJ5B492NhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-arm64-msvc/-/blake-hash-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-wWgAKZHuSjogu87S0/pJWij4kOrYRsQPR3ARQyaVtnJpI+vyRn+UcgJVTT+HfEdTytgIgzfZM9vosY8zLlcY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-ia32-msvc/-/blake-hash-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-b+dEb3VxN9cqPmrg1cDMFFFho/2d2xoAVU4Yi5x6CCRHnvUfKCuyxIpdM4dJmxppPcFXokI6zrsVg2iuJPyxgA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/blake-hash-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-x64-msvc/-/blake-hash-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-quVCzVvRTZaJRYbcBlWqoHG8v/+GWfn2HpbIyqbmTUeRfOV7V0r4HjJHRX+eKCmQiAygduWFWgl8jAEasSRGwg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/base58-native": {
@@ -52,12 +261,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "node_modules/blake3": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/blake3/-/blake3-2.1.7.tgz",
-      "integrity": "sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA==",
-      "hasInstallScript": true
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -89,6 +292,97 @@
     }
   },
   "dependencies": {
+    "@napi-rs/blake-hash": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash/-/blake-hash-1.3.0.tgz",
+      "integrity": "sha512-jPeAYGhP7J0vZecIIZz2dSx7ZW4zfhwR+zKEcbdRSGSyA240H9P6wVRtw1OWzIfMhE0X7rzZcOxZvl6CKI+Efg==",
+      "requires": {
+        "@napi-rs/blake-hash-android-arm64": "1.3.0",
+        "@napi-rs/blake-hash-darwin-arm64": "1.3.0",
+        "@napi-rs/blake-hash-darwin-x64": "1.3.0",
+        "@napi-rs/blake-hash-freebsd-x64": "1.3.0",
+        "@napi-rs/blake-hash-linux-arm-gnueabihf": "1.3.0",
+        "@napi-rs/blake-hash-linux-arm64-gnu": "1.3.0",
+        "@napi-rs/blake-hash-linux-arm64-musl": "1.3.0",
+        "@napi-rs/blake-hash-linux-x64-gnu": "1.3.0",
+        "@napi-rs/blake-hash-linux-x64-musl": "1.3.0",
+        "@napi-rs/blake-hash-win32-arm64-msvc": "1.3.0",
+        "@napi-rs/blake-hash-win32-ia32-msvc": "1.3.0",
+        "@napi-rs/blake-hash-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "@napi-rs/blake-hash-android-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-android-arm64/-/blake-hash-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-ADQB/N20z6ylNxbjzbxExtphrJb5HPC85pkc81C+KHS35b2e0j9pyzAhFgK3jUVJhHfJDVv6A6bhcTM9UNuP8A==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-darwin-arm64/-/blake-hash-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-Sh2jgMkKfC43FnsSWb8B23CURAmlO25agk+suIUIglHwQaRe5BKVVlJ5dpM0A0Zfu3zp5HH2GveYJf4wbFP79g==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-darwin-x64/-/blake-hash-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-NdMrOClD02LKRCBbFNuCzuSGiwXE7zjoiQZ3l1XyVHzVm3lI5KuoqkKBHqMuJnzUdvya3I8lT3gDrbu++Lb8nQ==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-freebsd-x64/-/blake-hash-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-8V7H0o317+mevBe2Rt5X98mSejHmd4pUtVLhmVcdvV3mVG/AkG7Yg6KQ5qO5krUYN3q4L5k5YkkyFkFKnQ+S5g==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm-gnueabihf/-/blake-hash-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-DYLrSBop5rbPsT61Kh8NDix33+x6QaQDXFymWKZ53eUtnwbI+vufA8kGElaVv8/g9/Q4SvuHs9ddiRdRWVZu7w==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm64-gnu/-/blake-hash-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-7NyNtetsGyCgUT/FWJSW/XElBujl5dGAp0sMjcXHMSEoNK98kVMmTLSzvBc3lLAU9F22WPUl0gbKlfEuzLqSXQ==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-arm64-musl/-/blake-hash-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-56CP0W+2epbehbJtXTcZS7HhjszDVetSs1GucDdeY3b+oIl5afPWV4b4CtkH+atKb+0FTcc4HFZnT4/Zu46N0Q==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-x64-gnu/-/blake-hash-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-00Idj9+JtCe4u/Cx/VvYsdUdNklP6oqKvRu0XSRuchO43LppihrN1Ew4Q/O0OjuWQQ1KyZhGmTjp63uSBP4dug==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-linux-x64-musl/-/blake-hash-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-znEOeC5ku8OpzTDwEKdnLNErTJw1QJCgV5u9ZmxebQeHKzXKiiRDO1N4PLtQo0Y+uVV1iuYZP/ZWGJ5B492NhQ==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-arm64-msvc/-/blake-hash-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-wWgAKZHuSjogu87S0/pJWij4kOrYRsQPR3ARQyaVtnJpI+vyRn+UcgJVTT+HfEdTytgIgzfZM9vosY8zLlcY9w==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-ia32-msvc/-/blake-hash-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-b+dEb3VxN9cqPmrg1cDMFFFho/2d2xoAVU4Yi5x6CCRHnvUfKCuyxIpdM4dJmxppPcFXokI6zrsVg2iuJPyxgA==",
+      "optional": true
+    },
+    "@napi-rs/blake-hash-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@napi-rs/blake-hash-win32-x64-msvc/-/blake-hash-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-quVCzVvRTZaJRYbcBlWqoHG8v/+GWfn2HpbIyqbmTUeRfOV7V0r4HjJHRX+eKCmQiAygduWFWgl8jAEasSRGwg==",
+      "optional": true
+    },
     "base58-native": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/base58-native/-/base58-native-0.1.4.tgz",
@@ -119,11 +413,6 @@
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
-    },
-    "blake3": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/blake3/-/blake3-2.1.7.tgz",
-      "integrity": "sha512-5d+TdKJvju96IyEaGJ0eO6CHbckWi+NBrCezGYM/WsnI3R03aLL2TWfsuZSh1rs0fTv/L3ps/r0vykjYurcIwA=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,17 +8,26 @@
   },
   "author": "alephium",
   "scripts": {
-    "start": "node ./init.js"
+    "start": "node ./init.js",
+    "build": "npx pkg . -C Brotli"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/alephium/mining-proxy.git"
   },
   "dependencies": {
-    "blake3": "2.1.7",
+    "@napi-rs/blake-hash": "1.3.0",
     "binary-parser": "2.0.2",
     "bignum": "0.13.1",
     "base58-native": "*"
+  },
+  "pkg": {
+    "scripts": "*.js",
+    "assets": "node_modules/**/*",
+    "outputPath": "bin"
+  },
+  "bin": {
+    "proxy": "init.js"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
As the title of the PR states.

I've had to replace the blake3 package in use, due to it's native binding being broken when built.

I've tested that the replacement has the same behaviour as the original.

package "blake3" replaced with "blake-hash" (https://github.com/Brooooooklyn/blake-hash).

[Here](https://github.com/capito27/mining-proxy/releases/tag/v9.9.12) is a link to a test-release produced by [this action](https://github.com/capito27/mining-proxy/actions/runs/1583065303) (ignore the failure on the Push Docker job, i had reverted to alephium's username by then)
